### PR TITLE
Generate overall log i.e., pm.log file inside log-dir

### DIFF
--- a/cmd/pm/pm.go
+++ b/cmd/pm/pm.go
@@ -28,18 +28,12 @@ func init() {
 	// DefaultConfigPath is default path for config file used when EnvConfFile is not set.
 	config.DefaultConfigPath = "/etc/pm.config.yaml"
 	// DefaultLogPath is default path for log file.
-	config.DefaultLogPath = "./"
-
+	config.DefaultLogPath = "./" + progname
 	// INFO: Use DefaultLogPath when it's available (until the config file is read).
-	// 	If not, use basename of file.
 	// NOTE: while running tests, the path of binary would be in `/tmp/<go-build*>`,
 	// so, using relative logging path w.r.t. binary wouldn't be accessible on Jenkins.
 	// So, use absolute path which also has write permissions (like current source directory).
-	myLogFile := config.DefaultLogPath
-	if _, err := os.Stat(filepath.Dir(myLogFile)); os.IsNotExist(err) {
-		myLogFile = progname
-	}
-	logutil.SetLogging(myLogFile)
+	logutil.SetLogging(config.DefaultLogPath)
 }
 
 func main() {

--- a/plugin.go
+++ b/plugin.go
@@ -702,20 +702,22 @@ func ScanCommandOptions(options map[string]interface{}) error {
 	if *CmdOptions.libraryPtr != "" {
 		config.SetPluginsLibrary(*CmdOptions.libraryPtr)
 	}
-	logToNewFile := false
+	myLogFile := "./"
 	if *CmdOptions.logDirPtr != "" {
 		config.SetPMLogDir(*CmdOptions.logDirPtr)
-		logToNewFile = true
+		myLogFile = config.GetPMLogDir()
 	}
 	// Info: Call set PM log-dir to clean extra slashes, and to append path
 	// 	separator at the end.
 	config.SetPMLogDir(config.GetPMLogDir())
 	if *CmdOptions.logFilePtr != "" {
 		config.SetPMLogFile(*CmdOptions.logFilePtr)
-		logToNewFile = true
+		myLogFile += config.GetPMLogFile()
+	} else {
+		myLogFile += progname
 	}
-	if logToNewFile {
-		myLogFile := config.GetPMLogDir() + config.GetPMLogFile()
+	if myLogFile != config.DefaultLogPath {
+		myLogFile = filepath.Clean(myLogFile)
 		log.Println("Logging to specified log file:", myLogFile)
 		logutil.SetLogging(myLogFile)
 	}


### PR DESCRIPTION

## Before fix

### Default was generating hidden file 

```bash
@abhijithda ➜ /workspaces/plugin-manager (v2 ✗) $ bin/pm run -library sample/library/ -type preupgrade 
Log: ..2023-03-17T00:13:28.515254529Z.log 
WARNING: Failed to read "/etc/pm.config.yaml" file.
WARNING: Failed to load config file. Using default values and proceeding with the operation

Checking for "D" settings...: Starting
Checking for "D" settings...: Failed

Checking for "A" settings: Starting
Checking for "A" settings: Skipped
Running preupgrade plugins: Failed
@abhijithda ➜ /workspaces/plugin-manager (v2 ✗) $
```

### Log-dir was becoming log file name when logfile wasn't specified

```log
@abhijithda ➜ /workspaces/plugin-manager (v2 ✗) $ bin/pm run -library sample/library/ -type preupgrade -log-dir ./logdir
Log: ..2023-03-17T00:14:54.942470989Z.log
WARNING: Failed to read "/etc/pm.config.yaml" file.
WARNING: Failed to load config file. Using default values and proceeding with the operation
Log: logdir.2023-03-17T00:14:54.942869387Z.log

Checking for "D" settings...: Starting
Checking for "D" settings...: Failed

Checking for "A" settings: Starting
Checking for "A" settings: Skipped
Running preupgrade plugins: Failed
@abhijithda ➜ /workspaces/plugin-manager (v2 ✗) $ 
```

### When both log-dir & log-file specified

```log
@abhijithda ➜ /workspaces/plugin-manager (v2 ✗) $ bin/pm run -library sample/library/ -type preupgrade -log-dir ./logdir -log-file logfile
Log: ..2023-03-17T00:15:38.317498666Z.log
WARNING: Failed to read "/etc/pm.config.yaml" file.
WARNING: Failed to load config file. Using default values and proceeding with the operation
Log: logdir/logfile.2023-03-17T00:15:38.317905864Z.log

Checking for "D" settings...: Starting
Checking for "D" settings...: Failed

Checking for "A" settings: Starting
Checking for "A" settings: Skipped
Running preupgrade plugins: Failed
@abhijithda ➜ /workspaces/plugin-manager (v2 ✗) $ 
```

## After fix

### Default generates log file as program name

```bash
@abhijithda ➜ /workspaces/plugin-manager (logdirfile ✗) $ bin/pm run -library sample/library/ -type preupgrade 
Log: pm.2023-03-17T00:10:51.111988159Z.log
WARNING: Failed to read "/etc/pm.config.yaml" file.
WARNING: Failed to load config file. Using default values and proceeding with the operation

Checking for "D" settings...: Starting
Checking for "D" settings...: Failed

Checking for "A" settings: Starting
Checking for "A" settings: Skipped
Running preupgrade plugins: Failed
@abhijithda ➜ /workspaces/plugin-manager (logdirfile ✗) $ 
```

### Logfile is now inside log-dir, and default log file is binary name

```log
@abhijithda ➜ /workspaces/plugin-manager (logdirfile ✗) $ bin/pm run -library sample/library/ -type preupgrade -log-dir ./logdir/ 
Log: pm.2023-03-17T00:17:55.899627821Z.log
WARNING: Failed to read "/etc/pm.config.yaml" file.
WARNING: Failed to load config file. Using default values and proceeding with the operation
Log: logdir/pm.2023-03-17T00:17:55.902538806Z.log

Checking for "D" settings...: Starting
Checking for "D" settings...: Failed

Checking for "A" settings: Starting
Checking for "A" settings: Skipped
Running preupgrade plugins: Failed
@abhijithda ➜ /workspaces/plugin-manager (logdirfile ✗) $ 
```

### When both log-dir & log-file specified (no regression)

```bash
@abhijithda ➜ /workspaces/plugin-manager (logdirfile ✗) $ bin/pm run -library sample/library/ -type preupgrade -log-dir ./logdir -log-file logfile
Log: pm.2023-03-17T00:10:11.274298889Z.log
WARNING: Failed to read "/etc/pm.config.yaml" file.
WARNING: Failed to load config file. Using default values and proceeding with the operation
Log: logdir/logfile.2023-03-17T00:10:11.275101885Z.log

Checking for "D" settings...: Starting
Checking for "D" settings...: Failed

Checking for "A" settings: Starting
Checking for "A" settings: Skipped
Running preupgrade plugins: Failed
@abhijithda ➜ /workspaces/plugin-manager (logdirfile ✗) $
```